### PR TITLE
Use hcl2json v0.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,15 @@ LABEL "maintainer"="Travis Truman <trumant@gmail.com>" \
 WORKDIR /usr/src/app
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/usr/src/app/native-helpers"
 
+# We use these to dynamically replace hcl2json v0.3.3 with v0.3.4 prior to
+# building the dependabot helpers.
+#
+# hcl2json v0.3.3 has a bug that causes a panic whenever a HCL file contains null values.
+ARG OLD_HCL2JSON_VER="v0.3.3"
+ARG OLD_HCL2JSON_CHECKSUM="24068f1e25a34d8f8ca763f34fce11527472891bfa834d1504f665855021d5d4"
+ARG NEW_HCL2JSON_VER="v0.3.4"
+ARG NEW_HCL2JSON_CHECKSUM="219d01706bc421a4daf11498058fc5d35cae6e9f764e7677e45cc35252dae0f1"
+
 COPY ./src /usr/src/app
 COPY ./src/run-action /usr/local/bin/run-action
 RUN apt-get update && \
@@ -20,10 +29,13 @@ RUN apt-get update && \
     bundle install && \
     mkdir -p $DEPENDABOT_NATIVE_HELPERS_PATH/terraform && \
     cp -r $(bundle show dependabot-terraform)/helpers $DEPENDABOT_NATIVE_HELPERS_PATH/terraform/helpers && \
+    sed -i 's/${OLD_HCL2JSON_VER}/${NEW_HCL2JSON_VER}/g' "${DEPENDABOT_NATIVE_HELPERS_PATH}/terraform/helpers/build" && \
+    sed -i 's/${OLD_HCL2JSON_CHECKSUM}/${NEW_HCL2JSON_CHECKSUM}/g' "${DEPENDABOT_NATIVE_HELPERS_PATH}/terraform/helpers/build" && \
     $DEPENDABOT_NATIVE_HELPERS_PATH/terraform/helpers/build $DEPENDABOT_NATIVE_HELPERS_PATH/terraform && \
     apt-get remove -y build-essential patch perl && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /tmp/*
+
 
 CMD ["run-action"]


### PR DESCRIPTION
The current version of dependabot uses version [0.3.3](https://github.com/dependabot/dependabot-core/blob/main/terraform/helpers/build#L19) of [hcl2json](https://github.com/tmccombs/hcl2json). This version of hcl2json contains a bug that causes dependabot to panic [whenever a Terraform object has a null value](https://github.com/tmccombs/hcl2json/issues/35). 

Here's an example stack trace caused by this bug:
```
Dependabot::DependencyFileNotParseable: panic: value is null
bundler: failed to load command: ./dependabot.rb (./dependabot.rb)

goroutine 1 [running]:
github.com/zclconf/go-cty/cty.Value.AsString(0x6b2700, 0xc0000b00fa, 0x0, 0x0, 0x6b2700, 0xc0000b00fa)
	/home/runner/go/pkg/mod/github.com/zclconf/go-cty@v1.8.1/cty/value_ops.go:1254 +0x185
github.com/tmccombs/hcl2json/convert.(*converter).convertStringPart(0xc000159d68, 0x6b2d98, 0xc000165800, 0x64d180, 0xc000170330, 0x10, 0x7f4eb23e55a0)
	/home/runner/work/hcl2json/hcl2json/convert/convert.go:243 +0x2f3
github.com/tmccombs/hcl2json/convert.(*converter).convertKey(0xc000159d68, 0x6b2e18, 0xc00009cd80, 0x110, 0x6402c0, 0x30, 0x30)
	/home/runner/work/hcl2json/hcl2json/convert/convert.go:266 +0x1ad
github.com/tmccombs/hcl2json/convert.(*converter).convertExpression(0xc000159d68, 0x6b2dd8, 0xc000168000, 0x4, 0xc000172748, 0x0, 0x0)
	/home/runner/work/hcl2json/hcl2json/convert/convert.go:187 +0x2d1
github.com/tmccombs/hcl2json/convert.(*converter).convertBody(0xc000159d68, 0xc0000c08f0, 0xc0000b0548, 0x8, 0xc0000bda68)
	/home/runner/work/hcl2json/hcl2json/convert/convert.go:87 +0x218
github.com/tmccombs/hcl2json/convert.(*converter).convertBlock(0xc000159d68, 0xc0000bd0e0, 0xc0000f2b10, 0x0, 0x0)
	/home/runner/work/hcl2json/hcl2json/convert/convert.go:137 +0x187
github.com/tmccombs/hcl2json/convert.(*converter).convertBody(0xc000159d68, 0xc0000c0e70, 0x110, 0x0, 0x0)
	/home/runner/work/hcl2json/hcl2json/convert/convert.go:80 +0xb7
github.com/tmccombs/hcl2json/convert.ConvertFile(0xc0000b9d40, 0x100, 0x0, 0xc0000b0590, 0x1)
	/home/runner/work/hcl2json/hcl2json/convert/convert.go:68 +0x8d
github.com/tmccombs/hcl2json/convert.File(0xc0000b9d40, 0x0, 0x0, 0x0, 0x0, 0x1, 0x1)
	/home/runner/work/hcl2json/hcl2json/convert/convert.go:37 +0x38
github.com/tmccombs/hcl2json/convert.Bytes(0xc00010a000, 0xaf0, 0xc00, 0x0, 0x0, 0x0, 0x0, 0xc000082000, 0x7f4e8b748cc8, 0x1, ...)
	/home/runner/work/hcl2json/hcl2json/convert/convert.go:27 +0xef
main.main()
	/home/runner/work/hcl2json/hcl2json/main.go:34 +0x296
  /usr/local/bundle/gems/dependabot-terraform-0.176.0/lib/dependabot/terraform/file_parser.rb:362:in `rescue in parsed_file'
  /usr/local/bundle/gems/dependabot-terraform-0.176.0/lib/dependabot/terraform/file_parser.rb:337:in `parsed_file'
  /usr/local/bundle/gems/dependabot-terraform-0.176.0/lib/dependabot/terraform/file_parser.rb:43:in `block in parse_terraform_files'
  /usr/local/bundle/gems/dependabot-terraform-0.176.0/lib/dependabot/terraform/file_parser.rb:42:in `each'
  /usr/local/bundle/gems/dependabot-terraform-0.176.0/lib/dependabot/terraform/file_parser.rb:42:in `parse_terraform_files'
  /usr/local/bundle/gems/dependabot-terraform-0.176.0/lib/dependabot/terraform/file_parser.rb:32:in `parse'
  /usr/src/app/dependabot.rb:95:in `update'
  /usr/src/app/dependabot.rb:140:in `block in <top (required)>'
  /usr/src/app/dependabot.rb:133:in `each'
  /usr/src/app/dependabot.rb:133:in `<top (required)>'
```

This PR ensures that we install v0.3.4 of hcl2json. 