### PR TITLE
Fix Installation of hcl2json v0.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,15 +11,6 @@ LABEL "maintainer"="Travis Truman <trumant@gmail.com>" \
 WORKDIR /usr/src/app
 ENV DEPENDABOT_NATIVE_HELPERS_PATH="/usr/src/app/native-helpers"
 
-# We use these to dynamically replace hcl2json v0.3.3 with v0.3.4 prior to
-# building the dependabot helpers.
-#
-# hcl2json v0.3.3 has a bug that causes a panic whenever a HCL file contains null values.
-ARG OLD_HCL2JSON_VER="v0.3.3"
-ARG OLD_HCL2JSON_CHECKSUM="24068f1e25a34d8f8ca763f34fce11527472891bfa834d1504f665855021d5d4"
-ARG NEW_HCL2JSON_VER="v0.3.4"
-ARG NEW_HCL2JSON_CHECKSUM="219d01706bc421a4daf11498058fc5d35cae6e9f764e7677e45cc35252dae0f1"
-
 COPY ./src /usr/src/app
 COPY ./src/run-action /usr/local/bin/run-action
 RUN apt-get update && \
@@ -29,13 +20,24 @@ RUN apt-get update && \
     bundle install && \
     mkdir -p $DEPENDABOT_NATIVE_HELPERS_PATH/terraform && \
     cp -r $(bundle show dependabot-terraform)/helpers $DEPENDABOT_NATIVE_HELPERS_PATH/terraform/helpers && \
-    sed -i 's/${OLD_HCL2JSON_VER}/${NEW_HCL2JSON_VER}/g' "${DEPENDABOT_NATIVE_HELPERS_PATH}/terraform/helpers/build" && \
-    sed -i 's/${OLD_HCL2JSON_CHECKSUM}/${NEW_HCL2JSON_CHECKSUM}/g' "${DEPENDABOT_NATIVE_HELPERS_PATH}/terraform/helpers/build" && \
     $DEPENDABOT_NATIVE_HELPERS_PATH/terraform/helpers/build $DEPENDABOT_NATIVE_HELPERS_PATH/terraform && \
     apt-get remove -y build-essential patch perl && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /tmp/*
 
+# By default, dependabot installs hcl2json v0.3.3 to parse Terraform files.
+# This release has a bug (see https://github.com/tmccombs/hcl2json/issues/35) that
+# causes a panic whenever a Terraform object has a null value.
+#
+# This bug was fixed in v0.3.4, so we overwrite the existing v0.3.3 installation of
+# hcl2json with v0.3.4.
+ARG HCL2JSON_URL="https://github.com/tmccombs/hcl2json/releases/download/v0.3.4/hcl2json_linux_amd64"
+ARG HCL2JSON_INSTALL_PATH="${DEPENDABOT_NATIVE_HELPERS_PATH}/terraform/bin/hcl2json"
+ARG HCL2JSON_CHECKSUM="219d01706bc421a4daf11498058fc5d35cae6e9f764e7677e45cc35252dae0f1"
+
+RUN curl -sSLfo ${HCL2JSON_INSTALL_PATH} ${HCL2JSON_URL} && \
+        echo ${HCL2JSON_CHECKSUM} ${HCL2JSON_INSTALL_PATH} | sha256sum -c && \
+        chmod +x ${HCL2JSON_INSTALL_PATH}
 
 CMD ["run-action"]

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://trumant/terraform-module-versions-action'
+  image: 'docker://cbbond/terraform-module-versions-action'
 branding:
   icon: 'package'
   color: 'orange'

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ inputs:
     required: false
 runs:
   using: 'docker'
-  image: 'docker://cbbond/terraform-module-versions-action'
+  image: 'docker://trumant/terraform-module-versions-action'
 branding:
   icon: 'package'
   color: 'orange'


### PR DESCRIPTION
The previous [PR](https://github.com/trumant/terraform-module-versions-action/pull/6) used sed to modify dependabot's installation script for hcl2json v0.3.4. It didn't work.

This PR fixes this issue by explicitly overwriting dependabot's installation of hcl2json with v0.3.4. This change has been tested and validated [here](https://github.com/HBOCodeLabs/Infra-Hurley-Ingestion-Lambda/runs/6278531436?check_suite_focus=true).